### PR TITLE
feat: Add time fast-forward to make timestamp based reveals work

### DIFF
--- a/tasks/deploy.ts
+++ b/tasks/deploy.ts
@@ -50,6 +50,16 @@ async function deployIntoNode(
     ],
   });
 
+  const block = await hre.ethers.provider.getBlock("latest");
+  const blockTime = new Date(block.timestamp * 1000);
+  const actualTime = new Date();
+  //@ts-expect-error
+  const timeDiffInMs = actualTime - blockTime;
+  const timeDiffInSec = Math.floor(timeDiffInMs / 1000);
+
+  // Fast forward the mockchain to be now
+  await hre.ethers.provider.send("evm_increaseTime", [timeDiffInSec]);
+
   await hre.run("compile");
 
   await runSuper(args);


### PR DESCRIPTION
Since we pinned the block to something on Tuesday, I was getting really strange behavior after doing a reveal. The game thought I had another one available but then reverted when I tried to submit again.

This just fast-forwards the local node to the current time so we can act like we are in a current game.