### PR TITLE
feat: Use interval mining so blocks increment for cancel

### DIFF
--- a/tasks/deploy.ts
+++ b/tasks/deploy.ts
@@ -67,4 +67,8 @@ async function deployIntoNode(
       });
     }
   }
+
+  // So blockNumber keeps incrementing
+  await hre.network.provider.send("evm_setAutomine", [false]);
+  await hre.network.provider.send("evm_setIntervalMining", [5000]);
 }


### PR DESCRIPTION
I was very confused when I issued a cancel and then the blocks never counted down. It was due to not mining blocks unless we interact.