### PR TITLE
feat: enable solidity optimizations

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -82,7 +82,15 @@ const xdai = {
 };
 
 const config: HardhatUserConfig = {
-  solidity: "0.8.4",
+  solidity: {
+    version: "0.8.4",
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 200,
+      },
+    },
+  },
   networks: {
     // Check for a DEPLOYER_MNEMONIC before we add xdai/mainnet network to the list of networks
     // Ex: If you try to deploy to xdai without DEPLOYER_MNEMONIC, you'll see this error:


### PR DESCRIPTION
No idea what a good runs number would be. DF uses 200, but not sure if that was a copy/paste job. 
More is more inlining and less gas costs (but more contract size presumably) I believe

https://github.com/ethereum/solidity/blob/develop/docs/internals/optimizer.rst
> The number of runs (--optimize-runs) specifies roughly how often each opcode of the deployed code will be executed across the life-time of the contract. This means it is a trade-off parameter between code size (deploy cost) and code execution cost (cost after deployment). A "runs" parameter of "1" will produce short but expensive code. In contrast, a larger "runs" parameter will produce longer but more gas efficient code. The maximum value of the parameter is 2**32-1.

Can benchmark this when necessary at some point.
