### PR TITLE
feat: Implement location ID broadcast requests

### DIFF
--- a/plugins/helpers/df.ts
+++ b/plugins/helpers/df.ts
@@ -82,10 +82,10 @@ export async function revealLocation(x: number, y: number): Promise<void> {
   });
 }
 
-export function getSelectedLocationId(): LocationId {
+export function getSelectedLocationId(): LocationId | undefined {
   //@ts-expect-error
   const planet = ui.getSelectedPlanet();
-  return planet?.locationId || EMPTY_LOCATION_ID;
+  return planet?.locationId;
 }
 
 export function getMyBalance(): number {

--- a/plugins/views/FulfillRequestsView.tsx
+++ b/plugins/views/FulfillRequestsView.tsx
@@ -167,7 +167,7 @@ export function FulfillRequestsView({ active, contract, revealRequests, onStatus
       }
       if (hideMyRequests) {
         if (requester === getAccount()) {
-          return true;
+          return false;
         }
       }
 

--- a/plugins/views/RequestRevealView.tsx
+++ b/plugins/views/RequestRevealView.tsx
@@ -37,12 +37,26 @@ const row = {
   margin: "7px 0",
 };
 
-const paymentInput = {
+const inpt = {
   color: "#080808",
   padding: "0 0 0 7px",
+  borderRadius: "3px",
+};
+
+const paymentInput = {
+  ...inpt,
   width: "100px",
   marginRight: "5px",
-  borderRadius: "3px",
+};
+
+const locationInput = {
+  ...inpt,
+  width: "170px",
+};
+
+const btn = {
+  width: "170px",
+  marginLeft: "auto",
 };
 
 function isRevealed(locationId: LocationId | undefined) {
@@ -116,7 +130,8 @@ export function RequestRevealView({ active, revealRequests, constants, onStatus,
   }
 
   function onUseSelected() {
-    setSelectedLocationId(getSelectedLocationId());
+    const locationId = getSelectedLocationId() || ("" as LocationId);
+    setSelectedLocationId(locationId);
   }
 
   function onChangeLocationId(evt: h.JSX.TargetedEvent<HTMLInputElement>) {
@@ -172,15 +187,17 @@ export function RequestRevealView({ active, revealRequests, constants, onStatus,
         <span style={beware}>Beware:</span> You will be spending actual xDai here!
       </div>
       <div style={row}>
-        <span>Your xDai Balance:</span>
-        <span>{balance} xDai</span>
+        <span>Location ID:</span>
+        <input style={locationInput} type="text" value={selectedLocationId} onKeyUp={onChangeLocationId} />
       </div>
       <div style={row}>
-        <span>Location ID:</span>
-        <span>
-          <input style={paymentInput} type="text" value={selectedLocationId} onKeyUp={onChangeLocationId} />
-          <button onClick={onUseSelected}>Selected planet</button>
-        </span>
+        <button style={btn} onClick={onUseSelected}>
+          Use Selected Planet
+        </button>
+      </div>
+      <div style={row}>
+        <span>Your xDai Balance:</span>
+        <span>{balance} xDai</span>
       </div>
       <div style={row}>
         <span>Paying:</span>

--- a/plugins/views/RequestRevealView.tsx
+++ b/plugins/views/RequestRevealView.tsx
@@ -1,4 +1,4 @@
-import type { Planet } from "@darkforest_eth/types";
+import type { Planet, LocationId } from "@darkforest_eth/types";
 
 import { h } from "preact";
 import { useState, useEffect } from "preact/hooks";
@@ -24,6 +24,8 @@ import {
   ViewProps,
 } from "../helpers/other";
 import { flex, hidden, beware, warning, fullWidth, shown as baseShown } from "../helpers/styles";
+import { EMPTY_LOCATION_ID } from "@darkforest_eth/constants";
+import { locationIdToDecStr, locationIdFromDecStr } from "@darkforest_eth/serde";
 
 const shown = {
   ...baseShown,
@@ -43,41 +45,59 @@ const paymentInput = {
   borderRadius: "3px",
 };
 
-function isRevealed(planet: Planet | undefined) {
-  return planet?.coordsRevealed === true;
-}
-
-function hasPendingRequest(planet: Planet | undefined, revealRequests: RevealRequest[]) {
-  if (!planet) return false;
-  return revealRequests.findIndex((req) => req.location === planet.locationId) !== -1;
-}
-
-function canRequestReveal(planet: Planet | undefined, revealRequests: RevealRequest[]) {
+function isRevealed(locationId: LocationId | undefined) {
+  const planet = getPlanetByLocationId(locationId);
   if (planet) {
-    return !isRevealed(planet) && !hasPendingRequest(planet, revealRequests);
+    return planet.coordsRevealed;
   } else {
     return false;
   }
 }
 
-export function RequestRevealView({ active, revealRequests, constants, onStatus, pending, setPending }: ViewProps) {
-  const [selectedLocationId, setSelectedLocationId] = useState(getSelectedLocationId);
+function hasPendingRequest(locationId: LocationId | undefined, revealRequests: RevealRequest[]) {
+  return revealRequests.findIndex((req) => req.location === locationId) !== -1;
+}
 
-  const planet = getPlanetByLocationId(selectedLocationId);
+function canRequestReveal(locationId: LocationId | undefined, revealRequests: RevealRequest[]) {
+  if (!locationId) {
+    return false;
+  }
+
+  if (locationId === EMPTY_LOCATION_ID) {
+    return false;
+  }
+
+  if (hasPendingRequest(locationId, revealRequests)) {
+    return false;
+  }
+
+  if (isRevealed(locationId)) {
+    return false;
+  }
+
+  try {
+    // locationIdFromDecStr will throw if it is invalid
+    // TODO: Would be nice to just have a validate function
+    if (locationIdFromDecStr(locationIdToDecStr(locationId))) {
+      return true;
+    }
+  } catch (err) {
+    console.log(err);
+    return false;
+  }
+}
+
+export function RequestRevealView({ active, revealRequests, constants, onStatus, pending, setPending }: ViewProps) {
+  const [selectedLocationId, setSelectedLocationId] = useState<LocationId>(undefined);
 
   const [balance, setBalance] = useState(getMyBalance);
-  const [canRequest, setCanRequest] = useState(() => canRequestReveal(planet, revealRequests));
+  const [canRequest, setCanRequest] = useState(() => canRequestReveal(selectedLocationId, revealRequests));
   const [xdai, setXdai] = useState(() => minWithoutFee(constants.REQUEST_MINIMUM, constants.FEE_PERCENT));
   const [minXdai] = useState(() => minWithoutFee(constants.REQUEST_MINIMUM, constants.FEE_PERCENT));
 
   useEffect(() => {
-    setCanRequest(canRequestReveal(planet, revealRequests));
-  }, [planet, revealRequests]);
-
-  useEffect(() => {
-    const sub = subscribeToSelectedLocationId(setSelectedLocationId);
-    return sub.unsubscribe;
-  }, [setSelectedLocationId]);
+    setCanRequest(canRequestReveal(selectedLocationId, revealRequests));
+  }, [selectedLocationId, revealRequests]);
 
   useEffect(() => {
     const sub = subscribeToMyBalance(setBalance);
@@ -95,6 +115,15 @@ export function RequestRevealView({ active, revealRequests, constants, onStatus,
     }
   }
 
+  function onUseSelected() {
+    setSelectedLocationId(getSelectedLocationId());
+  }
+
+  function onChangeLocationId(evt: h.JSX.TargetedEvent<HTMLInputElement>) {
+    const { value } = evt.currentTarget;
+    setSelectedLocationId(value as LocationId);
+  }
+
   // Ivan's fix didn't solve keyup
   function onKeyUp(evt: Event) {
     evt.stopPropagation();
@@ -110,26 +139,26 @@ export function RequestRevealView({ active, revealRequests, constants, onStatus,
     try {
       await requestReveal(selectedLocationId, totalEther);
       setPending(false);
-      setCanRequest(canRequestReveal(planet, revealRequests));
+      setCanRequest(canRequestReveal(selectedLocationId, revealRequests));
       onStatus({ message: "Successfully posted broadcast request!", color: colors.dfgreen, timeout: 5000 });
     } catch (err) {
       console.error("[BroadcastMarketPlugin] Error requesting broadcast", err);
       setPending(false);
-      setCanRequest(canRequestReveal(planet, revealRequests));
+      setCanRequest(canRequestReveal(selectedLocationId, revealRequests));
       onStatus({ message: "Error requesting broadcast. Try again.", color: colors.dfred });
     }
   }
 
   let btnMessage = "Request broadcast";
-  if (!planet) {
-    btnMessage = "No planet selected.";
+  if (!selectedLocationId) {
+    btnMessage = "No Location ID specified.";
   }
 
-  if (isRevealed(planet)) {
+  if (isRevealed(selectedLocationId)) {
     btnMessage = "Planet already broadcasted!";
   }
 
-  if (hasPendingRequest(planet, revealRequests)) {
+  if (hasPendingRequest(selectedLocationId, revealRequests)) {
     btnMessage = "Broadcast request already exists!";
   }
 
@@ -147,8 +176,11 @@ export function RequestRevealView({ active, revealRequests, constants, onStatus,
         <span>{balance} xDai</span>
       </div>
       <div style={row}>
-        <span>Request broadcast of:</span>
-        <span>{planetName(selectedLocationId)}</span>
+        <span>Location ID:</span>
+        <span>
+          <input style={paymentInput} type="text" value={selectedLocationId} onKeyUp={onChangeLocationId} />
+          <button onClick={onUseSelected}>Selected planet</button>
+        </span>
       </div>
       <div style={row}>
         <span>Paying:</span>


### PR DESCRIPTION
This adds a text box to the Request Broadcast tab to input a Location ID (this is now required) and a "Selected Planet" button to automatically set the Location ID to that of your selected planet (the old behavior).

When creating a request, if you know the location of the planet, it'll create a "known" request, otherwise it will create an unknown one with just the Location ID.

I created a couple with this and it seems to be working.

Here's a screenshot.
![Screen Shot 2021-07-03 at 9 19 05 PM](https://user-images.githubusercontent.com/992373/124373283-d6d3f000-dc45-11eb-8838-7414cc92c0c3.png)
