### PR TITLE
feat: Implement PlanetName component & use it for Cancel/Fulfill views

### DIFF
--- a/plugins/components/PlanetName.tsx
+++ b/plugins/components/PlanetName.tsx
@@ -1,0 +1,30 @@
+import type { LocationId } from "@darkforest_eth/types";
+
+import { h, FunctionComponent } from "preact";
+
+import { centerCoords, getCoordsByLocationId, planetName } from "../helpers/df";
+import { bold, jumpLink } from "../helpers/styles";
+
+type Props = {
+  locationId: LocationId;
+};
+
+export const PlanetName: FunctionComponent<Props> = ({ locationId }) => {
+  const coords = getCoordsByLocationId(locationId);
+
+  function centerPlanet() {
+    if (coords) {
+      centerCoords(coords);
+    }
+  }
+
+  if (coords) {
+    return (
+      <span style={jumpLink} onClick={centerPlanet}>
+        {planetName(locationId)} ({coords.x}, {coords.y})
+      </span>
+    );
+  } else {
+    return <span style={bold}>{planetName(locationId)}</span>;
+  }
+};

--- a/plugins/helpers/df.ts
+++ b/plugins/helpers/df.ts
@@ -5,7 +5,6 @@ import type { BroadcastMarket } from "../../types";
 
 import { BROADCAST_MARKET_ABI } from "../generated/abi";
 import { BROADCAST_MARKET_ADDRESS } from "../generated/contract";
-import { EMPTY_LOCATION_ID } from "@darkforest_eth/constants";
 
 //@ts-expect-error
 const { LOCATION_REVEAL_COOLDOWN }: { LOCATION_REVEAL_COOLDOWN: number } = ui.getContractConstants();
@@ -158,5 +157,14 @@ export function getLocatablePlanetByLocationId(locationId?: LocationId): Locatab
   const planet = getPlanetByLocationId(locationId);
   if (planet && isLocatable(planet)) {
     return planet;
+  }
+}
+
+export function getCoordsByLocationId(locationId: LocationId): WorldCoords | undefined {
+  const planet = getLocatablePlanetByLocationId(locationId);
+  if (planet) {
+    return planet.location.coords;
+  } else {
+    return undefined;
   }
 }

--- a/plugins/views/CancelRequestView.tsx
+++ b/plugins/views/CancelRequestView.tsx
@@ -28,6 +28,7 @@ import {
   jumpLink,
   optionsRow,
 } from "../helpers/styles";
+import { PlanetName } from "../components/PlanetName";
 
 type RowProps = {
   revealRequest: RevealRequest;
@@ -45,20 +46,13 @@ type CancelRowProps = RefundRowProps & {
 };
 
 const PaidRow: FunctionComponent<RowProps> = ({ revealRequest }) => {
-  const { x, y, payout, location, collector } = revealRequest;
-
-  function centerPlanet() {
-    centerCoords({ x, y });
-  }
+  const { payout, location, collector } = revealRequest;
 
   return (
     <div style={scrollListItem}>
       <div style={muted}>
         <div>
-          <span style={jumpLink} onClick={centerPlanet}>
-            {planetName(location)} ({x}, {y})
-          </span>{" "}
-          was broadcasted!
+          <PlanetName locationId={location} /> was broadcasted!
         </div>
         <div>
           {playerName(collector)} claimed <span style={bold}>{payout} xDai</span>.
@@ -69,20 +63,13 @@ const PaidRow: FunctionComponent<RowProps> = ({ revealRequest }) => {
 };
 
 const RefundedRow: FunctionComponent<RowProps> = ({ revealRequest }) => {
-  const { x, y, payout, location } = revealRequest;
-
-  function centerPlanet() {
-    centerCoords({ x, y });
-  }
+  const { payout, location } = revealRequest;
 
   return (
     <div style={scrollListItem}>
       <div style={muted}>
         <div>
-          <span style={jumpLink} onClick={centerPlanet}>
-            {planetName(location)} ({x}, {y})
-          </span>{" "}
-          request refunded.
+          <PlanetName locationId={location} /> request refunded.
         </div>
         <div>
           You got <span style={bold}>{payout} xDai</span> back.
@@ -100,11 +87,8 @@ const CancelRow: FunctionComponent<CancelRowProps> = ({
   pending,
   setPending,
 }) => {
-  const { x, y, payout, location } = revealRequest;
+  const { payout, location } = revealRequest;
 
-  function centerPlanet() {
-    centerCoords({ x, y });
-  }
   async function cancelReveal() {
     setPending(true);
     onStatus({ message: "Attempting to cancel request... Please wait...", color: colors.dfyellow });
@@ -130,10 +114,7 @@ const CancelRow: FunctionComponent<CancelRowProps> = ({
     <div style={scrollListItem}>
       <div style={muted}>
         <div>
-          Cancel{" "}
-          <span style={jumpLink} onClick={centerPlanet}>
-            {planetName(location)} ({x}, {y})
-          </span>
+          Cancel <PlanetName locationId={location} />
         </div>
         <div>
           and claim <span style={bold}>{payout} xDai</span> refund in
@@ -148,13 +129,10 @@ const CancelRow: FunctionComponent<CancelRowProps> = ({
 };
 
 const RefundRow: FunctionComponent<RefundRowProps> = ({ revealRequest, contract, onStatus, pending, setPending }) => {
-  const { x, y, payout, location, cancelCompleteBlock } = revealRequest;
+  const { payout, location, cancelCompleteBlock } = revealRequest;
 
   const [remainingBlocks, setRemainingBlocks] = useState(() => cancelCompleteBlock - getBlockNumber());
 
-  function centerPlanet() {
-    centerCoords({ x, y });
-  }
   async function claimRefund() {
     setPending(true);
     onStatus({ message: "Attempting to claim refund... Please wait...", color: colors.dfyellow });
@@ -188,11 +166,7 @@ const RefundRow: FunctionComponent<RefundRowProps> = ({ revealRequest, contract,
           <span style={bold}> {remainingBlocks > 0 ? remainingBlocks : 0}</span> blocks
         </div>
         <div>
-          for{" "}
-          <span style={jumpLink} onClick={centerPlanet}>
-            {planetName(location)} ({x}, {y})
-          </span>
-          .
+          for <PlanetName locationId={location} />.
         </div>
       </div>
       <Button onClick={claimRefund} enabled={remainingBlocks <= 0 && !pending}>

--- a/plugins/views/FulfillRequestsView.tsx
+++ b/plugins/views/FulfillRequestsView.tsx
@@ -20,8 +20,9 @@ import {
   getPlanetByLocationId,
   isLocatable,
   getLocatablePlanetByLocationId,
+  getCoordsByLocationId,
 } from "../helpers/df";
-import { decodeCoords, getCoords, RevealRequest, ViewProps } from "../helpers/other";
+import { getCoords, RevealRequest, ViewProps } from "../helpers/other";
 import {
   shown,
   hidden,
@@ -36,6 +37,7 @@ import {
   optionsRow,
 } from "../helpers/styles";
 import { WorldCoords } from "@darkforest_eth/types";
+import { PlanetName } from "../components/PlanetName";
 
 type RowProps = {
   revealRequest: RevealRequest;
@@ -52,12 +54,6 @@ function timeFromNow() {
 const Row: FunctionComponent<RowProps> = ({ text, revealRequest, canReveal, onReveal }) => {
   const { location, payout, requester, cancelCompleteBlock } = revealRequest;
 
-  const planet = getLocatablePlanetByLocationId(location);
-  let coords;
-  if (planet) {
-    coords = planet.location.coords;
-  }
-
   const [remainingBlocks, setRemainingBlocks] = useState(() => cancelCompleteBlock - getBlockNumber());
 
   useEffect(() => {
@@ -67,12 +63,6 @@ const Row: FunctionComponent<RowProps> = ({ text, revealRequest, canReveal, onRe
 
     return sub.unsubscribe;
   }, [cancelCompleteBlock]);
-
-  function centerPlanet() {
-    if (coords) {
-      centerCoords({ x: coords.x, y: coords.y });
-    }
-  }
 
   const cancelWarning =
     cancelCompleteBlock !== 0 ? (
@@ -87,14 +77,7 @@ const Row: FunctionComponent<RowProps> = ({ text, revealRequest, canReveal, onRe
     <div style={scrollListItem}>
       <div style={muted}>
         <div>
-          Broadcast{" "}
-          {coords ? (
-            <span style={jumpLink} onClick={centerPlanet}>
-              {planetName(location)} ({coords.x}, {coords.y})
-            </span>
-          ) : (
-            <span style={bold}>{planetName(location)}</span>
-          )}
+          Broadcast <PlanetName locationId={location} />
         </div>
         <div>
           and receive <span style={bold}>{payout} xDai</span> from {playerName(requester)}
@@ -194,10 +177,7 @@ export function FulfillRequestsView({ active, contract, revealRequests, onStatus
             return;
           }
         } else {
-          const planet = getLocatablePlanetByLocationId(revealRequest.location);
-          if (planet) {
-            coords = planet.location.coords;
-          }
+          coords = getCoordsByLocationId(revealRequest.location);
         }
         if (!coords) {
           console.error("[BroadcastMarketPlugin] Unable to get coords for planet", revealRequest.location);

--- a/plugins/views/RequestRevealView.tsx
+++ b/plugins/views/RequestRevealView.tsx
@@ -9,9 +9,7 @@ import { Button } from "../components/Button";
 import {
   getSelectedLocationId,
   getMyBalance,
-  subscribeToSelectedLocationId,
   subscribeToMyBalance,
-  planetName,
   getPlanetByLocationId,
   colors,
 } from "../helpers/df";
@@ -23,7 +21,7 @@ import {
   sumEtherStrings,
   ViewProps,
 } from "../helpers/other";
-import { flex, hidden, beware, warning, fullWidth, shown as baseShown } from "../helpers/styles";
+import { flex, hidden, beware, warning, shown as baseShown } from "../helpers/styles";
 import { EMPTY_LOCATION_ID } from "@darkforest_eth/constants";
 import { locationIdToDecStr, locationIdFromDecStr } from "@darkforest_eth/serde";
 


### PR DESCRIPTION
This updates the Cancel Request view to use a new component PlanetName that looks up the planet coords from your map data and handles showing it as a clickable link or just a bold planet name (if you don't know the location).

I also re-used that component in Fulfill Requests and cleaned up some references no longer used.