### PR TITLE
chore: Update hardhat-network-fork submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "cache/hardhat-network-fork"]
 	path = cache/hardhat-network-fork
 	url = git://github.com/projectsophon/hardhat-network-fork
+	branch = main

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -104,7 +104,7 @@ const config: HardhatUserConfig = {
       forking: {
         enabled: true,
         url: "https://xdai-archive.blockscout.com/",
-        blockNumber: 17587738,
+        blockNumber: 17568384,
       },
     },
   },

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -104,7 +104,7 @@ const config: HardhatUserConfig = {
       forking: {
         enabled: true,
         url: "https://xdai-archive.blockscout.com/",
-        blockNumber: 17568384,
+        blockNumber: 17587738,
       },
     },
   },


### PR DESCRIPTION
As requested by @cha0sg0d in discord, this updates the hardhat-network-cache to the blockNumber that I initialized in at. 